### PR TITLE
feat: Enhance leaflet types, improve map component typings and added DatabaseRow interface to typed

### DIFF
--- a/components/interactive-map.tsx
+++ b/components/interactive-map.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useLanguage } from "@/components/language-provider";
 import { MapPin } from "lucide-react";
+import type { Map } from "leaflet";
 
 interface InteractiveMapProps {
   latitude: number;
@@ -14,7 +15,7 @@ interface InteractiveMapProps {
 
 export default function InteractiveMap({ latitude, longitude, name, address, className = "" }: InteractiveMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
-  const mapInstanceRef = useRef<any>(null);
+  const mapInstanceRef = useRef<Map | null>(null);
   const [isReady, setIsReady] = useState(false);
   const { t } = useLanguage();
 
@@ -31,7 +32,7 @@ export default function InteractiveMap({ latitude, longitude, name, address, cla
         await import("leaflet/dist/leaflet.css");
 
         // Fix for default markers in Leaflet with webpack
-        delete (L.Icon.Default.prototype as any)._getIconUrl;
+        delete (L.Icon.Default.prototype as Record<string, unknown>)._getIconUrl;
         L.Icon.Default.mergeOptions({
           iconRetinaUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png",
           iconUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png",

--- a/lib/db-transform.ts
+++ b/lib/db-transform.ts
@@ -3,13 +3,18 @@
  * This avoids code duplication across client and server components
  */
 
-import type { Market } from "./markets-data";
+import type { Market, MarketSchedule } from "./markets-data";
+
+/**
+ * Database row structure from Supabase
+ * Represents the flattened schema where nested objects are stored as JSONB or separate columns
+ */
 
 /**
  * Transform a database row to a Market object
  * Handles JSONB parsing (both string and object formats)
  */
-export function dbRowToMarket(row: any): Market {
+export function dbRowToMarket(row: DatabaseRow): Market {
   return {
     id: row.id,
     name: row.name,
@@ -53,6 +58,33 @@ export function dbRowToMarket(row: any): Market {
 /**
  * Transform multiple database rows to Market objects
  */
-export function dbRowsToMarkets(rows: any[]): Market[] {
+export function dbRowsToMarkets(rows: DatabaseRow[]): Market[] {
   return rows.map(dbRowToMarket);
+}
+
+export interface DatabaseRow {
+  id: string;
+  name: string;
+  address: string;
+  district: string;
+  state: string;
+  status: string;
+  description?: string | null;
+  area_m2?: number | null;
+  total_shop?: number | null;
+  shop_list?: string | null;
+
+  // Parking fields (flattened)
+  parking_available?: boolean | null;
+  parking_accessible?: boolean | null;
+  parking_notes?: string | null;
+
+  // Amenities fields (flattened)
+  amen_toilet?: boolean | null;
+  amen_prayer_room?: boolean | null;
+
+  // JSONB fields (can be string or already parsed object)
+  contact?: string | { phone?: string; email?: string } | null;
+  location?: string | { latitude: number; longitude: number; gmaps_link: string } | null;
+  schedule?: string | MarketSchedule[] | null;
 }

--- a/lib/geolocation.ts
+++ b/lib/geolocation.ts
@@ -80,8 +80,8 @@ export async function requestUserLocation(options?: PositionOptions): Promise<{ 
 
   // Best-effort Permissions API check to avoid silent failures when already denied
   try {
-    if ("permissions" in navigator && typeof (navigator as any).permissions?.query === "function") {
-      const status: PermissionStatus = await (navigator as any).permissions.query({
+    if ("permissions" in navigator && typeof navigator.permissions?.query === "function") {
+      const status: PermissionStatus = await navigator.permissions.query({
         name: "geolocation" as PermissionName,
       });
       if (status.state === "denied") {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,7 +6,8 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 // Time helpers for market open status
-import type { Market, Weekday } from "@/lib/markets-data";
+import type { Market, MarketSchedule, Weekday } from "@/lib/markets-data";
+import { DayCode } from "@/app/enums";
 
 interface OpenStatus {
   status: "open" | "closed";
@@ -29,19 +30,19 @@ function parseTimeToMinutes(time24: string): number {
 
 function weekdayIndex(code: Weekday): number {
   switch (code) {
-    case "mon":
+    case DayCode.Mon:
       return 1;
-    case "tue":
+    case DayCode.Tue:
       return 2;
-    case "wed":
+    case DayCode.Wed:
       return 3;
-    case "thu":
+    case DayCode.Thu:
       return 4;
-    case "fri":
+    case DayCode.Fri:
       return 5;
-    case "sat":
+    case DayCode.Sat:
       return 6;
-    case "sun":
+    case DayCode.Sun:
       return 0;
     default:
       return 0;
@@ -58,7 +59,7 @@ export function getMarketOpenStatus(market: Market, now?: Date): OpenStatus {
   const ranges: Range[] = [];
 
   for (const rule of market.schedule || []) {
-    const days: Weekday[] = (rule as any).days || [];
+    const days: Weekday[] = (rule as MarketSchedule).days || [];
     for (const day of days) {
       for (const t of rule.times || []) {
         const start = parseTimeToMinutes(t.start);

--- a/types/leaflet.d.ts
+++ b/types/leaflet.d.ts
@@ -1,5 +1,93 @@
 declare module "leaflet" {
-  const L: any;
+  export interface LatLng {
+    lat: number;
+    lng: number;
+  }
+
+  export type LatLngExpression = [number, number] | LatLng;
+
+  export interface MapOptions {
+    center?: LatLngExpression;
+    zoom?: number;
+    [key: string]: unknown;
+  }
+
+  export interface Map {
+    setView(center: LatLngExpression, zoom: number): Map;
+    addTo(map: Map): Map;
+    removeLayer(layer: TileLayer | Marker): void;
+    on(event: string, handler: () => void): void;
+    invalidateSize(): void;
+    remove(): void;
+    flyTo(latlng: LatLngExpression, zoom?: number, options?: { animate?: boolean; duration?: number }): void;
+    fitBounds(bounds: LatLngBounds, options?: { pad?: number }): void;
+    zoomIn(): void;
+    zoomOut(): void;
+  }
+
+  export interface TileLayer {
+    addTo(map: Map): TileLayer;
+  }
+
+  export interface IconOptions {
+    iconRetinaUrl?: string;
+    iconUrl?: string;
+    shadowUrl?: string;
+    iconSize?: [number, number];
+    iconAnchor?: [number, number];
+    html?: string;
+    className?: string;
+  }
+
+  export interface IconDefault {
+    prototype: Record<string, unknown> & {
+      _getIconUrl?: () => string;
+    };
+    mergeOptions(options: IconOptions): void;
+  }
+
+  export interface Icon {
+    Default: IconDefault;
+  }
+
+  export interface DivIconOptions {
+    html?: string;
+    className?: string;
+    iconSize?: [number, number];
+    iconAnchor?: [number, number];
+  }
+
+  export interface DivIcon {}
+
+  export interface MarkerOptions {
+    icon?: DivIcon;
+  }
+
+  export interface Marker {
+    addTo(map: Map): Marker;
+    bindPopup(content: string): Marker;
+    openPopup(): Marker;
+    on(event: string, handler: () => void): void;
+  }
+
+  export interface LatLngBounds {
+    pad(bufferRatio: number): LatLngBounds;
+  }
+
+  export interface FeatureGroup {
+    getBounds(): LatLngBounds;
+  }
+
+  export interface LeafletStatic {
+    map(element: HTMLElement | null, options?: MapOptions): Map;
+    tileLayer(urlTemplate: string, options?: Record<string, unknown>): TileLayer;
+    Icon: Icon;
+    divIcon(options: DivIconOptions): DivIcon;
+    marker(latlng: LatLngExpression, options?: MarkerOptions): Marker;
+    featureGroup(layers: Marker[]): FeatureGroup;
+  }
+
+  const L: LeafletStatic;
   export default L;
 }
 


### PR DESCRIPTION
TLDR: Remove all use of 'any'. Replaced it with proper types

1. Use proper leaflet types
2. Infer db-transform.ts types based on what is in Market type
3. Declared a global Window interface to solve the window as any problem
4. Removed unnecessary new keyword in market-map.tsx

Zero any types, now all types are proper following TypeScript best practice, making auto completion easy in the future and better code maintainability.